### PR TITLE
Created new method update one by

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "speck-sequelize-repository",
-  "version": "0.1.2",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "speck-sequelize-repository",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Repositories using Speck",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "speck-sequelize-repository",
-  "version": "0.1.2",
+  "version": "1.0.0",
   "description": "Repositories using Speck",
   "main": "src/index.js",
   "scripts": {

--- a/src/BaseRepository.test.js
+++ b/src/BaseRepository.test.js
@@ -320,6 +320,77 @@ describe('BaseRepository', () => {
         }
         expect(executeFunc).to.throw('where clause is required!')
       })
+
+      it('update one item by criterias', () => {
+        const whereClause = {
+          primaryKey1: 1
+        }
+        const recordInstance = {
+          fieldToUpdate: 'new value'
+        }
+
+        const fieldsToUpdate = ['fieldToUpdate']
+        const relationshipFields = { fieldToUpdate: 'some value' }
+
+        mapper.toDatabase = stub()
+        mapper.toDatabase
+          .withArgs({ fieldToUpdate: recordInstance.fieldToUpdate })
+          .returns({ fieldToUpdate: recordInstance.fieldToUpdate })
+        mapper.toDatabase
+          .withArgs({ primaryKey1: whereClause.primaryKey1 })
+          .returns({ primaryKey1: whereClause.primaryKey1 })
+
+        const expectedConstraints = {
+          where: {
+            primaryKey1: whereClause.primaryKey1
+          },
+          limit: 1,
+          fields: ['fieldToUpdate']
+        }
+
+        sequelizeModel.update = mock()
+          .once()
+          .withExactArgs(relationshipFields, expectedConstraints)
+          .resolves('udate result')
+
+        return repository.updateOneBy(whereClause, recordInstance, fieldsToUpdate, relationshipFields)
+          .then(result => expect(recordInstance).to.equal(result))
+      })
+
+      it('#updateOneBy returns error when invalid where clause', () => {
+        const whereClause = {}
+        const recordInstance = {
+          fieldToUpdate: 'new value'
+        }
+
+        const fieldsToUpdate = ['fieldToUpdate']
+        const relationshipFields = { fieldToUpdate: 'some value' }
+
+        mapper.toDatabase = stub()
+        mapper.toDatabase
+          .withArgs({ fieldToUpdate: recordInstance.fieldToUpdate })
+          .returns({ fieldToUpdate: recordInstance.fieldToUpdate })
+        mapper.toDatabase
+          .withArgs({})
+          .returns({})
+
+        const expectedConstraints = {
+          where: {},
+          limit: 1,
+          fields: ['fieldToUpdate']
+        }
+
+        sequelizeModel.update = mock()
+          .once()
+          .withExactArgs(relationshipFields, expectedConstraints)
+          .resolves('udate result')
+
+        const executeFunc = function () {
+          return repository.updateOneBy(whereClause, recordInstance, fieldsToUpdate)
+        }
+
+        expect(executeFunc).to.throw('where clause is required!')
+      })
     })
 
     describe('#updateByDiff', () => {


### PR DESCRIPTION
Hi,

I just implemented a new method that I thought is more secure and can be used when updating a single item. In this implementation, I pass the `option.limit = 1` to sequelize to guarantee that one item will be affected.

    const instanceEntity = new MyEntity({...data})
    const primaryKey = 1
    await myModel.updateOneBy({ primaryKey }, instanceEntity, ['myAttrToUpdate'])

